### PR TITLE
Fix filter exception

### DIFF
--- a/qmgr.py
+++ b/qmgr.py
@@ -45,7 +45,7 @@ class QueueManager(object):
 			self.singerRotation = self.singerRotation[1:] + self.singerRotation[:1]
 
 		# If you don't have anything queued, you lose your place in the scheduler.
-		self.singerRotation = filter(lambda singer: singer in singerQueues, self.singerRotation)
+		self.singerRotation = list(filter(lambda singer: singer in singerQueues, self.singerRotation))
 
 		if self.hideSingers:
 			# Deduplicate songs, keeping the first.


### PR DESCRIPTION
When this project is run with python 3, the following exception occurs:
```
Exception in thread Thread-61:
Traceback (most recent call last):
  File "/usr/lib/python3.7/threading.py", line 926, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.7/threading.py", line 1177, in run
    self.function(*self.args, **self.kwargs)
  File "scheduler.py", line 25, in inner
    return f(*args, **kwargs)
  File "scheduler.py", line 84, in handle
    action = qm.reconcile(data)
  File "/home/coandco/git/karafun-fair-scheduler/qmgr.py", line 38, in reconcile
    self.singerRotation.append(singer)
AttributeError: 'filter' object has no attribute 'append'
```

This pull request fixes the issue by wrapping the `filter` call in a `list()` casting.  Thanks a ton for writing karafun-fair-scheduler -- with this fix I was able to use this at a karaoke party and it worked like a charm!