### PR TITLE
Update the scheduler to work with the new URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Usage is simple:
 
 ```shell
-$ pip install python-socketio
+$ pip install "python-socketio<5.0.0"
 $ python scheduler.py 123456
 ```
 

--- a/scheduler.py
+++ b/scheduler.py
@@ -101,5 +101,5 @@ def serverUnreacheable():
 def disconnect():
 	print('Disconnected from server.')
 
-sio.connect('https://www.karafun.com/?remote=kf%s' % args.channel)
+sio.connect('https://www.karafun.com/socket.io/?remote=kf%s' % args.channel)
 sio.wait()


### PR DESCRIPTION
Karafun changed the URL for their SocketIO server, so that has to be updated for this to continue working.  Separately, installing `python-socketio` now installs version 5.x.x of the library, which uses version 4 of the EngineIO library and is incompatible with Karafun (which uses version 3 of EngineIO).  I've modified the installation instructions in the readme to note that it requires version 4.x.x of `python-socketio` to work.

This fixes the issue I just opened (#4).